### PR TITLE
Content: Define all YearCompass questions as data structure

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -380,3 +380,154 @@ textarea {
   font-style: italic;
   color: var(--color-text);
 }
+
+/* Life Areas */
+.life-area,
+.life-area-goal {
+  padding: var(--spacing-lg);
+  margin-bottom: var(--spacing-lg);
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+}
+
+.life-area h4,
+.life-area-goal h4 {
+  margin: 0 0 var(--spacing-md);
+  font-size: var(--font-size-lg);
+  color: var(--color-text);
+}
+
+.rating-control {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-md);
+}
+
+.rating-control input[type="range"] {
+  flex: 1;
+  height: 8px;
+  -webkit-appearance: none;
+  appearance: none;
+  background: var(--color-border);
+  border-radius: 4px;
+  outline: none;
+}
+
+.rating-control input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 20px;
+  height: 20px;
+  background: var(--color-accent);
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+.rating-control input[type="range"]::-moz-range-thumb {
+  width: 20px;
+  height: 20px;
+  background: var(--color-accent);
+  border-radius: 50%;
+  cursor: pointer;
+  border: none;
+}
+
+.rating-value {
+  min-width: 24px;
+  text-align: center;
+  font-weight: 600;
+  color: var(--color-accent);
+}
+
+.goal-field,
+.actions-field {
+  margin-bottom: var(--spacing-md);
+}
+
+.goal-field:last-child,
+.actions-field:last-child {
+  margin-bottom: 0;
+}
+
+/* Triplet Groups */
+.triplet-group {
+  padding: var(--spacing-lg);
+  margin-bottom: var(--spacing-lg);
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+}
+
+.triplet-group h4 {
+  margin: 0 0 var(--spacing-md);
+  font-size: var(--font-size-base);
+  color: var(--color-text);
+}
+
+.triplet-group input[type="text"] {
+  margin-bottom: var(--spacing-sm);
+}
+
+.triplet-group input[type="text"]:last-child {
+  margin-bottom: 0;
+}
+
+/* Section Content (Info sections) */
+.section-content {
+  line-height: var(--line-height-relaxed);
+}
+
+.section-content h3 {
+  margin: var(--spacing-xl) 0 var(--spacing-md);
+  font-size: var(--font-size-lg);
+  color: var(--color-text);
+}
+
+.section-content ul {
+  padding-left: var(--spacing-xl);
+  margin: var(--spacing-md) 0;
+}
+
+.section-content li {
+  margin-bottom: var(--spacing-sm);
+}
+
+.section-content a {
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+.section-content a:hover {
+  text-decoration: underline;
+}
+
+.intro-lead,
+.preparation-lead {
+  font-size: var(--font-size-lg);
+  color: var(--color-text);
+}
+
+.preparation-ready {
+  margin-top: var(--spacing-xl);
+  padding: var(--spacing-md);
+  background-color: var(--color-background);
+  border-radius: var(--border-radius);
+  text-align: center;
+}
+
+/* Nav Part Headers */
+.nav-part-header {
+  padding: var(--spacing-md) var(--spacing-md) var(--spacing-sm);
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+}
+
+.nav-part-header:not(:first-child) {
+  margin-top: var(--spacing-md);
+  border-top: 1px solid var(--color-border);
+  padding-top: var(--spacing-lg);
+}

--- a/data/questions.js
+++ b/data/questions.js
@@ -2,11 +2,52 @@
  * YearCompass Questions Data Structure
  * All sections, prompts, and fields for the YearCompass exercise
  *
- * This is a placeholder structure - full content will be added in Issue #3
+ * Structure follows SPEC.md with three parts:
+ * - Part 0: Introduction
+ * - Part 1: The Past Year (Closing)
+ * - Part 2: The Year Ahead (Planning)
  */
 
+/**
+ * Life areas used for assessment and goal-setting
+ */
+export const lifeAreas = [
+  { id: 'personal-growth', label: 'Personal growth / Self-care' },
+  { id: 'career', label: 'Career / Studies' },
+  { id: 'friends', label: 'Friends / Community' },
+  { id: 'family', label: 'Family' },
+  { id: 'romantic', label: 'Romantic relationship' },
+  { id: 'fun', label: 'Fun / Recreation' },
+  { id: 'physical-health', label: 'Physical health / Fitness' },
+  { id: 'mental-health', label: 'Mental health / Spirituality' },
+  { id: 'finances', label: 'Finances' },
+  { id: 'home', label: 'Home / Living environment' },
+  { id: 'creativity', label: 'Creative expression' },
+  { id: 'other', label: 'Other' }
+];
+
+/**
+ * Magical triplets for Part 2
+ */
+export const magicalTriplets = [
+  { id: 'love-about-self', prompt: 'Three things I will love about myself' },
+  { id: 'let-go', prompt: 'Three things I\'m ready to let go of' },
+  { id: 'achieve', prompt: 'Three things I want to achieve the most' },
+  { id: 'pillars', prompt: 'Three people who will be my pillars during rough times' },
+  { id: 'discover', prompt: 'Three things I will dare to discover' },
+  { id: 'say-no', prompt: 'Three things I will have the power to say no to' },
+  { id: 'cozy', prompt: 'Three things I will make my surroundings cozy with' },
+  { id: 'places', prompt: 'Three places I will visit' },
+  { id: 'pamper', prompt: 'Three things I will pamper myself with regularly' },
+  { id: 'morning', prompt: 'Three things I will do every morning' },
+  { id: 'rewards', prompt: 'Three presents I will reward my successes with' },
+  { id: 'connect', prompt: 'Three ways I will connect with my loved ones' }
+];
+
 export const sections = [
+  // ==========================================
   // Part 0: Introduction
+  // ==========================================
   {
     id: 'intro',
     part: 0,
@@ -14,9 +55,18 @@ export const sections = [
     type: 'info',
     skippable: false,
     content: `
-      <p>Welcome to YearCompass, your companion for yearly reflection and planning.</p>
-      <p>This is a digital version of the free YearCompass booklet.</p>
-      <p>Plan for 3-4 hours, or complete over multiple sessions. Your progress saves automatically.</p>
+      <div class="intro-content">
+        <p class="intro-lead">Welcome to <strong>YearCompass</strong>, your companion for yearly reflection and planning.</p>
+        <p>This is a digital version of the free YearCompass booklet from <a href="https://yearcompass.com" target="_blank" rel="noopener">yearcompass.com</a>.</p>
+        <h3>Before you begin</h3>
+        <ul>
+          <li><strong>Plan for 3-4 hours</strong>, or complete over multiple sessions</li>
+          <li><strong>Your progress saves automatically</strong> - you can close this anytime and return later</li>
+          <li><strong>Be honest with yourself</strong> - this is for your eyes only</li>
+          <li><strong>There are no right answers</strong> - write whatever comes to mind</li>
+        </ul>
+        <p>When you're ready, click <strong>Next</strong> to begin with a short preparation exercise.</p>
+      </div>
     `
   },
   {
@@ -26,54 +76,270 @@ export const sections = [
     type: 'info',
     skippable: true,
     content: `
-      <p><strong>Take three deep breaths.</strong> Settle into your space.</p>
-      <p>Find a quiet place. Make yourself comfortable.</p>
-      <p>Set aside judgment. Be honest with yourself.</p>
+      <div class="preparation-content">
+        <p class="preparation-lead">Before diving into reflection, take a moment to settle in.</p>
+
+        <h3>Create your space</h3>
+        <p>Find a quiet place where you won't be disturbed. Make yourself comfortable. Perhaps make a warm drink.</p>
+
+        <h3>Clear your mind</h3>
+        <p><strong>Take three deep breaths.</strong></p>
+        <p>Breathe in slowly... hold... and release.</p>
+        <p>Let go of the day's concerns. This time is just for you.</p>
+
+        <h3>Set your intention</h3>
+        <p>Set aside judgment. Be honest with yourself. Remember: there are no wrong answers here.</p>
+        <p>You're about to close one chapter and open another. Approach this with curiosity and kindness toward yourself.</p>
+
+        <p class="preparation-ready">When you feel ready, click <strong>Next</strong> to begin reflecting on your past year.</p>
+      </div>
     `
   },
 
-  // Part 1: The Past Year - Placeholder sections
+  // ==========================================
+  // Part 1: The Past Year (Closing)
+  // ==========================================
   {
     id: 'calendar-review',
     part: 1,
     title: 'Calendar Review',
-    description: 'Go through last year\'s calendar week by week. Write down important events, gatherings, and significant moments.',
+    description: 'Go through last year\'s calendar week by week. Write down important events, gatherings, milestones, and significant moments. What happened in January? February? And so on...',
     fields: [
-      { id: 'calendar-notes', type: 'textarea', rows: 10, markdown: true }
+      {
+        id: 'calendar-notes',
+        type: 'textarea',
+        rows: 15,
+        markdown: true,
+        prompt: 'Review your year month by month:'
+      }
     ]
   },
   {
     id: 'year-in-review',
     part: 1,
     title: 'This Year In Review',
-    description: 'Complete these sentences to reflect on your past year.',
+    description: 'Complete these sentences to reflect on key moments and learnings from your past year.',
     fields: [
-      { id: 'wisest-decision', type: 'textarea', prompt: 'The wisest decision I made...', rows: 3 },
-      { id: 'biggest-lesson', type: 'textarea', prompt: 'The biggest lesson I learned...', rows: 3 },
-      { id: 'biggest-risk', type: 'textarea', prompt: 'The biggest risk I took...', rows: 3 },
-      { id: 'biggest-surprise', type: 'textarea', prompt: 'The biggest surprise of the year...', rows: 3 },
-      { id: 'for-others', type: 'textarea', prompt: 'The most important thing I did for others...', rows: 3 },
-      { id: 'biggest-completed', type: 'textarea', prompt: 'The biggest thing I completed...', rows: 3 }
+      { id: 'wisest-decision', type: 'textarea', prompt: 'The wisest decision I made...', rows: 3, markdown: true },
+      { id: 'biggest-lesson', type: 'textarea', prompt: 'The biggest lesson I learned...', rows: 3, markdown: true },
+      { id: 'biggest-risk', type: 'textarea', prompt: 'The biggest risk I took...', rows: 3, markdown: true },
+      { id: 'biggest-surprise', type: 'textarea', prompt: 'The biggest surprise of the year...', rows: 3, markdown: true },
+      { id: 'for-others', type: 'textarea', prompt: 'The most important thing I did for others...', rows: 3, markdown: true },
+      { id: 'biggest-completed', type: 'textarea', prompt: 'The biggest thing I completed...', rows: 3, markdown: true }
+    ]
+  },
+  {
+    id: 'highlights',
+    part: 1,
+    title: 'Highlights',
+    description: 'Recall your greatest, most memorable, and joyful moments from the past year.',
+    fields: [
+      {
+        id: 'greatest-moments',
+        type: 'textarea',
+        prompt: 'Describe your greatest, most memorable, and joyful moments from last year:',
+        rows: 5,
+        markdown: true
+      },
+      {
+        id: 'moment-feelings',
+        type: 'textarea',
+        prompt: 'How did you feel? Who was there? What were you doing?',
+        rows: 5,
+        markdown: true
+      }
+    ]
+  },
+  {
+    id: 'accomplishments-challenges',
+    part: 1,
+    title: 'Accomplishments & Challenges',
+    description: 'Reflect on what you achieved and what was difficult.',
+    fields: [
+      { id: 'accomplishment-1', type: 'text', prompt: 'My greatest accomplishment #1:' },
+      { id: 'accomplishment-2', type: 'text', prompt: 'My greatest accomplishment #2:' },
+      { id: 'accomplishment-3', type: 'text', prompt: 'My greatest accomplishment #3:' },
+      { id: 'challenge-1', type: 'text', prompt: 'My biggest challenge #1:' },
+      { id: 'challenge-2', type: 'text', prompt: 'My biggest challenge #2:' },
+      { id: 'challenge-3', type: 'text', prompt: 'My biggest challenge #3:' }
+    ]
+  },
+  {
+    id: 'forgiveness',
+    part: 1,
+    title: 'Forgiveness',
+    description: 'Is there anything from the past year that still needs to be forgiven? Deeds or words that made you feel bad?',
+    fields: [
+      {
+        id: 'forgiveness-reflection',
+        type: 'textarea',
+        prompt: 'Who do you need to forgive, or ask forgiveness from? What do you need to forgive yourself for?',
+        rows: 6,
+        markdown: true
+      }
+    ]
+  },
+  {
+    id: 'letting-go',
+    part: 1,
+    title: 'Letting Go',
+    description: 'What are you ready to release from the past year? What beliefs, habits, or burdens no longer serve you?',
+    fields: [
+      {
+        id: 'letting-go-reflection',
+        type: 'textarea',
+        prompt: 'What are you ready to let go of from the past year?',
+        rows: 6,
+        markdown: true
+      }
+    ]
+  },
+  {
+    id: 'life-areas-past',
+    part: 1,
+    title: 'Life Areas Assessment',
+    description: 'Rate your satisfaction in each area of life over the past year (1 = very dissatisfied, 10 = very satisfied). Add notes about what contributed to your rating.',
+    type: 'life-areas',
+    fields: lifeAreas.map(area => ({
+      id: area.id,
+      label: area.label,
+      type: 'rating-with-notes'
+    }))
+  },
+  {
+    id: 'past-year-summary',
+    part: 1,
+    title: 'Summary of the Past Year',
+    description: 'Wrap up your reflection on the past year.',
+    fields: [
+      { id: 'word-1', type: 'text', prompt: 'Word #1 that defines your past year:' },
+      { id: 'word-2', type: 'text', prompt: 'Word #2 that defines your past year:' },
+      { id: 'word-3', type: 'text', prompt: 'Word #3 that defines your past year:' },
+      {
+        id: 'book-title',
+        type: 'text',
+        prompt: 'If a book or movie was made about your past year, what title would you give it?'
+      },
+      {
+        id: 'farewell-letter',
+        type: 'textarea',
+        prompt: 'Write a farewell letter to the past year. Thank it, acknowledge it, and let it go.',
+        rows: 8,
+        markdown: true
+      }
     ]
   },
 
-  // Part 2: The Year Ahead - Placeholder sections
+  // ==========================================
+  // Part 2: The Year Ahead (Planning)
+  // ==========================================
   {
     id: 'dare-to-dream',
     part: 2,
     title: 'Dare to Dream',
-    description: 'What does the year ahead look like? Why will it be great? Write, draw, let go of expectations and dare to dream.',
+    description: 'Close your eyes and imagine the year ahead. What does the ideal year look like? Let go of expectations and dare to dream big.',
     fields: [
-      { id: 'dreams', type: 'textarea', rows: 10, markdown: true }
+      {
+        id: 'dreams',
+        type: 'textarea',
+        prompt: 'What does the year ahead look like? Why will it be great? What would happen in an ideal world?',
+        rows: 12,
+        markdown: true
+      }
+    ]
+  },
+  {
+    id: 'magical-triplets',
+    part: 2,
+    title: 'Magical Triplets',
+    description: 'Complete each set of three. Don\'t overthink it - write what comes to mind.',
+    type: 'triplets',
+    triplets: magicalTriplets
+  },
+  {
+    id: 'affirmations',
+    part: 2,
+    title: 'Affirmations',
+    description: 'Complete these sentences to set your intentions for the year ahead.',
+    fields: [
+      { id: 'special-because', type: 'textarea', prompt: 'This year will be special for me because...', rows: 3, markdown: true },
+      { id: 'advise-myself', type: 'textarea', prompt: 'This year I advise myself to...', rows: 3, markdown: true },
+      { id: 'say-yes-when', type: 'textarea', prompt: 'This year I will say yes when...', rows: 3, markdown: true },
+      { id: 'bravest-when', type: 'textarea', prompt: 'This year I will be the bravest when...', rows: 3, markdown: true },
+      { id: 'energy-from', type: 'textarea', prompt: 'This year I will draw the most energy from...', rows: 3, markdown: true },
+      { id: 'not-procrastinate', type: 'textarea', prompt: 'This year I will not procrastinate any more on...', rows: 3, markdown: true }
     ]
   },
   {
     id: 'word-of-year',
     part: 2,
     title: 'Word of the Year',
-    description: 'Pick a word to symbolize and define the year ahead. You can look at this word when you need extra energy.',
+    description: 'Pick a single word to symbolize and define the year ahead. This word can be your anchor - look at it when you need extra energy or direction.',
     fields: [
-      { id: 'word', type: 'text', prompt: 'My word for the year:' }
+      {
+        id: 'word',
+        type: 'text',
+        prompt: 'My word for the year:'
+      },
+      {
+        id: 'word-meaning',
+        type: 'textarea',
+        prompt: 'Why did you choose this word? What does it mean to you?',
+        rows: 4,
+        markdown: true
+      }
+    ]
+  },
+  {
+    id: 'secret-wish',
+    part: 2,
+    title: 'Secret Wish',
+    description: 'Unleash your mind. What is your deepest, most secret wish for the year ahead?',
+    fields: [
+      {
+        id: 'secret-wish',
+        type: 'textarea',
+        prompt: 'My secret wish for this year:',
+        rows: 5,
+        markdown: true
+      }
+    ]
+  },
+  {
+    id: 'life-areas-future',
+    part: 2,
+    title: 'Life Areas Goals',
+    description: 'For each area of life, set intentions for the year ahead. What do you want to achieve? What actions will you take?',
+    type: 'life-areas-goals',
+    fields: lifeAreas.map(area => ({
+      id: area.id,
+      label: area.label,
+      type: 'goal-with-actions'
+    }))
+  },
+  {
+    id: 'commitment',
+    part: 2,
+    title: 'Commitment',
+    description: 'Seal your intentions with a commitment to yourself.',
+    fields: [
+      {
+        id: 'commitment-statement',
+        type: 'textarea',
+        prompt: 'I commit to pursuing my goals and living according to my values. I will be kind to myself when I fall short, and celebrate my progress along the way.',
+        rows: 4,
+        markdown: true
+      },
+      {
+        id: 'signature',
+        type: 'text',
+        prompt: 'Your name (as a signature):'
+      },
+      {
+        id: 'date',
+        type: 'text',
+        prompt: 'Today\'s date:'
+      }
     ]
   }
 ];
@@ -94,4 +360,28 @@ export function getSection(id) {
  */
 export function getSectionsByPart(part) {
   return sections.filter(s => s.part === part);
+}
+
+/**
+ * Get total field count for progress calculation
+ * @returns {number} Total number of fillable fields
+ */
+export function getTotalFieldCount() {
+  let count = 0;
+
+  sections.forEach(section => {
+    if (section.type === 'info') return;
+
+    if (section.type === 'triplets') {
+      // 12 triplets × 3 items each = 36 fields
+      count += (section.triplets?.length || 0) * 3;
+    } else if (section.type === 'life-areas' || section.type === 'life-areas-goals') {
+      // Each life area has rating + notes (2 fields) or goal + actions (2 fields)
+      count += (section.fields?.length || 0) * 2;
+    } else {
+      count += section.fields?.length || 0;
+    }
+  });
+
+  return count;
 }

--- a/js/render.js
+++ b/js/render.js
@@ -60,6 +60,9 @@ export function renderSection(sectionId) {
     case 'life-areas':
       renderLifeAreasSection(container, section, sectionData.answers);
       break;
+    case 'life-areas-goals':
+      renderLifeAreasGoalsSection(container, section, sectionData.answers);
+      break;
     case 'triplets':
       renderTripletsSection(container, section, sectionData.answers);
       break;
@@ -125,6 +128,48 @@ function renderLifeAreasSection(container, section, answers = {}) {
         rows="2"
         aria-label="Notes for ${escapeHtml(field.label)}"
       >${escapeHtml(notesValue)}</textarea>
+    `;
+
+    // Set up auto-save listeners
+    setupFieldListeners(fieldEl);
+
+    container.appendChild(fieldEl);
+  });
+}
+
+/**
+ * Render a life areas goals section (for year ahead planning)
+ */
+function renderLifeAreasGoalsSection(container, section, answers = {}) {
+  const fields = section.fields || [];
+
+  fields.forEach(field => {
+    const fieldEl = document.createElement('div');
+    fieldEl.className = 'life-area-goal field';
+
+    const goalValue = answers[`${field.id}-goal`] || '';
+    const actionsValue = answers[`${field.id}-actions`] || '';
+
+    fieldEl.innerHTML = `
+      <h4>${escapeHtml(field.label)}</h4>
+      <div class="goal-field">
+        <label for="${field.id}-goal" class="field-prompt">What do you want to achieve?</label>
+        <textarea
+          id="${field.id}-goal"
+          data-field-id="${field.id}-goal"
+          rows="2"
+          aria-label="Goal for ${escapeHtml(field.label)}"
+        >${escapeHtml(goalValue)}</textarea>
+      </div>
+      <div class="actions-field">
+        <label for="${field.id}-actions" class="field-prompt">What actions will you take?</label>
+        <textarea
+          id="${field.id}-actions"
+          data-field-id="${field.id}-actions"
+          rows="2"
+          aria-label="Actions for ${escapeHtml(field.label)}"
+        >${escapeHtml(actionsValue)}</textarea>
+      </div>
     `;
 
     // Set up auto-save listeners


### PR DESCRIPTION
Closes #3

## Summary
Complete implementation of all YearCompass questions and sections as defined in SPEC.md.

## Changes

### data/questions.js
- Added `lifeAreas` array with all 12 life areas from SPEC.md
- Added `magicalTriplets` array with all 12 triplet prompts
- Defined all 17 sections across 3 parts:
  - **Part 0**: Welcome intro, Preparation ritual
  - **Part 1**: Calendar Review, Year In Review (6 prompts), Highlights, Accomplishments & Challenges, Forgiveness, Letting Go, Life Areas Assessment (12 areas with ratings), Summary
  - **Part 2**: Dare to Dream, Magical Triplets (12×3=36 inputs), Affirmations (6 prompts), Word of the Year, Secret Wish, Life Areas Goals (12 areas with goal+actions), Commitment
- Added `getTotalFieldCount()` helper for progress calculation

### js/render.js
- Added `renderLifeAreasGoalsSection()` for Part 2 goal-setting UI

### css/styles.css
- Added styles for life areas (ratings, cards)
- Added styles for triplet groups
- Added styles for section content (intro, preparation)
- Added nav part header styles

## Testing
- Verified all section types render correctly
- Tested Life Areas Assessment with rating sliders
- Tested Magical Triplets with 3-input groups
- App initializes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)