### PR TITLE
Navigation: Sidebar and section navigation system

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -531,3 +531,75 @@ textarea {
   border-top: 1px solid var(--color-border);
   padding-top: var(--spacing-lg);
 }
+
+/* Nav Item with Completion Indicator */
+.nav-list button {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: var(--font-size-sm);
+}
+
+.nav-item-title {
+  flex: 1;
+  text-align: left;
+}
+
+.nav-item-check {
+  color: var(--color-success);
+  font-size: var(--font-size-sm);
+  margin-left: var(--spacing-sm);
+}
+
+/* Mobile Sidebar */
+@media (max-width: 767px) {
+  .sidebar {
+    position: fixed;
+    top: var(--header-height);
+    left: 0;
+    bottom: 0;
+    width: 280px;
+    transform: translateX(-100%);
+    transition: transform var(--transition-base);
+    z-index: 50;
+    display: block;
+  }
+
+  .sidebar.open {
+    transform: translateX(0);
+  }
+
+  .sidebar-toggle {
+    display: flex;
+    position: fixed;
+    top: calc(var(--header-height) + var(--spacing-md));
+    left: var(--spacing-md);
+    z-index: 40;
+    background-color: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius);
+    box-shadow: var(--shadow-sm);
+  }
+}
+
+/* Skip Section Nudge */
+.skip-nudge {
+  position: fixed;
+  bottom: calc(var(--footer-height) + var(--spacing-lg));
+  left: 50%;
+  transform: translateX(-50%) translateY(20px);
+  background-color: var(--color-text);
+  color: var(--color-surface);
+  padding: var(--spacing-sm) var(--spacing-lg);
+  border-radius: var(--border-radius);
+  font-size: var(--font-size-sm);
+  opacity: 0;
+  transition: opacity var(--transition-base), transform var(--transition-base);
+  pointer-events: none;
+  z-index: 200;
+}
+
+.skip-nudge.visible {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}

--- a/js/render.js
+++ b/js/render.js
@@ -5,7 +5,7 @@
 
 import { sections } from '../data/questions.js';
 import { getCurrentYear, saveAnswer } from './storage.js';
-import { updateProgress } from './navigation.js';
+import { updateProgress, updateSidebarIndicators } from './navigation.js';
 
 /**
  * Escape HTML characters to prevent XSS and broken markup
@@ -290,8 +290,9 @@ function setupFieldListeners(container) {
           updateSaveStatus('Saved');
         }, 400);
 
-        // Update progress
+        // Update progress and sidebar indicators
         updateProgress();
+        updateSidebarIndicators();
       }
     });
 

--- a/js/storage.js
+++ b/js/storage.js
@@ -174,6 +174,43 @@ export function saveSettings(settings) {
   saveToLocalStorage();
 }
 
+/**
+ * Get the current section for the active year
+ * @returns {string} Current section ID or 'intro' as default
+ */
+export function getCurrentSection() {
+  const year = getCurrentYear();
+  return year?.currentSection || 'intro';
+}
+
+/**
+ * Save the current section for the active year
+ * @param {string} sectionId - Section ID to save
+ */
+export function saveCurrentSection(sectionId) {
+  const year = getCurrentYear();
+  if (year) {
+    year.currentSection = sectionId;
+    year.lastModified = new Date().toISOString();
+    debouncedSave();
+  }
+}
+
+/**
+ * Check if a section has any content filled
+ * @param {string} sectionId - Section ID to check
+ * @returns {boolean} True if section has any filled fields
+ */
+export function isSectionStarted(sectionId) {
+  const year = getCurrentYear();
+  if (!year?.sections[sectionId]?.answers) return false;
+
+  const answers = year.sections[sectionId].answers;
+  return Object.values(answers).some(value =>
+    value && typeof value === 'string' && value.trim().length > 0
+  );
+}
+
 // Debounce save operations
 let saveTimeout = null;
 function debouncedSave() {


### PR DESCRIPTION
Closes #5

## Summary
Implements the complete navigation system for YearCompass with sidebar navigation, section persistence, and progress tracking.

## Features
- **Sidebar completion indicators**: Checkmarks appear next to sections that have been started
- **Current section persistence**: Remembers where user left off between sessions
- **URL hash navigation**: Direct linking to sections via `#section-id` (e.g., `#calendar-review`)
- **Skip nudge**: Gentle "You can come back to this anytime" message when jumping ahead past incomplete sections
- **Progress tracking**: Real-time percentage display as content is filled in
- **Mobile sidebar**: Slide-in navigation on smaller screens

## Files Changed
- `js/navigation.js` - Complete navigation system implementation
- `js/storage.js` - Added section tracking functions (getCurrentSection, saveCurrentSection, isSectionStarted)
- `js/render.js` - Import and call updateSidebarIndicators on content changes
- `css/styles.css` - Navigation item styles, mobile sidebar, skip nudge styling

## Testing
- [x] Navigation between all 17 sections works
- [x] URL hash changes when navigating
- [x] Section persists across page refresh
- [x] Completion checkmarks appear when content is entered
- [x] Skip nudge appears when jumping past incomplete sections
- [x] Progress percentage updates in real-time

🤖 Generated with [Claude Code](https://claude.com/claude-code)