### PR TITLE
PDF Export: Print stylesheet and export functionality

### DIFF
--- a/css/print.css
+++ b/css/print.css
@@ -3,7 +3,20 @@
  * Used when exporting to PDF via browser print dialog
  */
 
+/* Hide print container when not printing */
+.print-container {
+  display: none;
+}
+
 @media print {
+  /* Show print container, hide app */
+  .print-container {
+    display: block !important;
+  }
+
+  body.printing #app {
+    display: none !important;
+  }
   /* Hide UI chrome */
   .app-header,
   .sidebar,
@@ -11,16 +24,25 @@
   .sidebar-toggle,
   .btn,
   .year-selector,
-  .progress-container {
+  .progress-container,
+  .markdown-toggle,
+  .skip-nudge,
+  .new-year-banner {
     display: none !important;
   }
 
   /* Reset layout */
+  * {
+    -webkit-print-color-adjust: exact !important;
+    print-color-adjust: exact !important;
+  }
+
   body {
-    background: white;
-    color: black;
-    font-size: 12pt;
-    line-height: 1.5;
+    background: white !important;
+    color: black !important;
+    font-size: 11pt;
+    line-height: 1.6;
+    font-family: Georgia, 'Times New Roman', Times, serif;
   }
 
   #app {
@@ -34,56 +56,217 @@
   .main-content {
     padding: 0;
     overflow: visible;
+    max-width: none;
+  }
+
+  .main-content > * {
+    max-width: none;
+  }
+
+  /* Print header - Year title */
+  .print-header {
+    text-align: center;
+    margin-bottom: 2em;
+    padding-bottom: 1em;
+    border-bottom: 2px solid #333;
+  }
+
+  .print-header h1 {
+    font-size: 24pt;
+    margin: 0 0 0.25em;
+    font-weight: normal;
+  }
+
+  .print-header .print-date {
+    font-size: 10pt;
+    color: #666;
   }
 
   /* Section styling for print */
   .section {
     page-break-inside: avoid;
-    margin-bottom: 2em;
+    margin-bottom: 1.5em;
   }
 
   .section-title {
-    font-size: 18pt;
+    font-size: 16pt;
     font-weight: bold;
     margin-bottom: 0.5em;
-    border-bottom: 1px solid #ccc;
+    border-bottom: 1px solid #999;
     padding-bottom: 0.25em;
+    page-break-after: avoid;
   }
 
-  /* Show content fields */
-  textarea,
-  input[type="text"] {
-    border: none;
-    padding: 0;
-    background: transparent;
-    font-size: 11pt;
-    min-height: auto;
-    height: auto;
+  .section-description {
+    font-size: 10pt;
+    color: #666;
+    font-style: italic;
+    margin-bottom: 1em;
   }
 
-  /* Rendered markdown content */
-  .markdown-preview {
-    padding: 0;
-    background: transparent;
-  }
-
-  /* Page breaks between major sections */
-  .section[data-part="1"]:first-of-type {
-    page-break-before: always;
-  }
-
+  /* Page breaks between parts */
+  .section[data-part="1"]:first-of-type,
   .section[data-part="2"]:first-of-type {
     page-break-before: always;
   }
 
-  /* Print header/footer (if supported) */
+  /* Part headers in print */
+  .print-part-header {
+    font-size: 20pt;
+    font-weight: bold;
+    text-align: center;
+    margin: 1em 0;
+    padding: 0.5em 0;
+    border-top: 2px solid #333;
+    border-bottom: 2px solid #333;
+    page-break-after: avoid;
+  }
+
+  /* Field styling */
+  .field {
+    margin-bottom: 1em;
+    page-break-inside: avoid;
+  }
+
+  .field-prompt {
+    font-weight: bold;
+    font-style: italic;
+    margin-bottom: 0.25em;
+    display: block;
+  }
+
+  /* Text inputs and textareas - show as content */
+  textarea,
+  input[type="text"] {
+    border: none !important;
+    padding: 0.5em !important;
+    background: #f9f9f9 !important;
+    font-size: 10pt;
+    min-height: auto !important;
+    height: auto !important;
+    width: 100% !important;
+    font-family: Georgia, 'Times New Roman', Times, serif;
+    white-space: pre-wrap;
+    resize: none;
+  }
+
+  /* Empty fields */
+  textarea:empty::before,
+  input[type="text"]:placeholder-shown {
+    content: "(No response)";
+    color: #999;
+    font-style: italic;
+  }
+
+  /* Rendered markdown content */
+  .markdown-preview {
+    display: block !important;
+    padding: 0.5em !important;
+    background: #f9f9f9 !important;
+    border: none !important;
+    font-size: 10pt;
+  }
+
+  .markdown-wrapper textarea {
+    display: none !important;
+  }
+
+  /* Life Areas styling */
+  .life-area,
+  .life-area-goal {
+    border: 1px solid #ccc;
+    padding: 0.75em;
+    margin-bottom: 0.75em;
+    page-break-inside: avoid;
+    background: white !important;
+  }
+
+  .life-area h4,
+  .life-area-goal h4 {
+    font-size: 12pt;
+    margin: 0 0 0.5em;
+    border-bottom: 1px solid #ddd;
+    padding-bottom: 0.25em;
+  }
+
+  .rating-control {
+    margin-bottom: 0.5em;
+  }
+
+  .rating-control input[type="range"] {
+    display: none;
+  }
+
+  .rating-value {
+    font-size: 14pt;
+    font-weight: bold;
+  }
+
+  .rating-value::before {
+    content: "Rating: ";
+    font-weight: normal;
+    font-size: 10pt;
+  }
+
+  .rating-value::after {
+    content: " / 10";
+    font-weight: normal;
+    font-size: 10pt;
+  }
+
+  /* Triplet groups */
+  .triplet-group {
+    border: 1px solid #ccc;
+    padding: 0.75em;
+    margin-bottom: 0.75em;
+    page-break-inside: avoid;
+    background: white !important;
+  }
+
+  .triplet-group h4 {
+    font-size: 11pt;
+    margin: 0 0 0.5em;
+  }
+
+  .triplet-group input[type="text"] {
+    display: block;
+    margin-bottom: 0.25em;
+  }
+
+  /* Section content (info sections) */
+  .section-content {
+    display: none;
+  }
+
+  /* Goal/Actions fields */
+  .goal-field,
+  .actions-field {
+    margin-bottom: 0.5em;
+  }
+
+  .goal-field label,
+  .actions-field label {
+    font-size: 10pt;
+    font-weight: bold;
+  }
+
+  /* Page settings */
   @page {
-    margin: 1in;
-    @top-center {
-      content: "YearCompass";
-    }
-    @bottom-center {
-      content: counter(page);
-    }
+    margin: 0.75in;
+    size: letter;
+  }
+
+  @page :first {
+    margin-top: 0.5in;
+  }
+
+  /* Links */
+  a {
+    color: black !important;
+    text-decoration: none !important;
+  }
+
+  a[href]::after {
+    content: none !important;
   }
 }

--- a/js/app.js
+++ b/js/app.js
@@ -8,6 +8,7 @@ import { initNavigation } from './navigation.js';
 import { renderSection } from './render.js';
 import { initYearSelector, checkNewYearPrompt } from './year.js';
 import { initSaveIndicator } from './save-indicator.js';
+import { initPdfExport } from './pdf.js';
 
 /**
  * Initialize the YearCompass application
@@ -33,6 +34,9 @@ async function init() {
 
     // Check if we should prompt for new year
     checkNewYearPrompt();
+
+    // Initialize PDF export
+    initPdfExport();
 
     // Remove loading state
     const mainContent = document.getElementById('main-content');

--- a/js/pdf.js
+++ b/js/pdf.js
@@ -1,8 +1,10 @@
 /**
  * PDF Export Module
- * Prepares content for browser print dialog
+ * Prepares and renders all content for browser print dialog
  */
 
+import { getCurrentYear } from './storage.js';
+import { sections, lifeAreas, magicalTriplets } from '../data/questions.js';
 import { renderMarkdown } from './markdown.js';
 
 /**
@@ -20,46 +22,314 @@ export function initPdfExport() {
  * Export the current compass to PDF via browser print
  */
 export function exportToPdf() {
-  // Prepare content for printing
-  prepareForPrint();
+  const yearData = getCurrentYear();
+  if (!yearData) {
+    alert('No year data to export. Please fill in some content first.');
+    return;
+  }
+
+  // Create print container with all content
+  const printContainer = createPrintContainer(yearData);
+  document.body.appendChild(printContainer);
+
+  // Add print class to body
+  document.body.classList.add('printing');
 
   // Trigger browser print dialog
   window.print();
 
   // Restore after print
-  window.addEventListener('afterprint', restoreAfterPrint, { once: true });
+  window.addEventListener('afterprint', () => {
+    restoreAfterPrint(printContainer);
+  }, { once: true });
 }
 
 /**
- * Prepare the document for printing
- * - Renders all markdown content
- * - Expands all sections
+ * Create the print container with all sections rendered
+ * @param {Object} yearData - Current year data from storage
+ * @returns {HTMLElement} The print container element
  */
-function prepareForPrint() {
-  // Render markdown in all textareas
-  const markdownFields = document.querySelectorAll('[data-markdown="true"]');
+function createPrintContainer(yearData) {
+  const container = document.createElement('div');
+  container.id = 'print-container';
+  container.className = 'print-container';
 
-  markdownFields.forEach(textarea => {
-    const value = textarea.value;
-    if (value) {
-      const preview = document.createElement('div');
-      preview.className = 'markdown-preview print-only';
-      preview.innerHTML = renderMarkdown(value);
-      textarea.parentElement.appendChild(preview);
+  // Add print header
+  container.appendChild(createPrintHeader(yearData));
+
+  // Track current part for part headers
+  let currentPart = null;
+
+  // Render each section (skip info sections)
+  sections.forEach(section => {
+    if (section.type === 'info') return;
+
+    // Add part header when part changes
+    if (section.part !== currentPart && section.part > 0) {
+      currentPart = section.part;
+      container.appendChild(createPartHeader(currentPart));
     }
+
+    // Get section data
+    const sectionData = yearData.sections[section.id] || { answers: {} };
+
+    // Check if section has any content
+    if (!hasContent(sectionData.answers)) return;
+
+    // Render the section
+    container.appendChild(renderPrintSection(section, sectionData.answers));
   });
 
-  // Add print class to body
-  document.body.classList.add('printing');
+  return container;
+}
+
+/**
+ * Create the print header with year and date
+ * @param {Object} yearData - Current year data
+ * @returns {HTMLElement} Print header element
+ */
+function createPrintHeader(yearData) {
+  const header = document.createElement('header');
+  header.className = 'print-header';
+
+  const title = document.createElement('h1');
+  title.textContent = `YearCompass ${yearData.displayName || yearData.id}`;
+
+  const date = document.createElement('div');
+  date.className = 'print-date';
+  date.textContent = `Exported on ${formatDate(new Date())}`;
+
+  header.appendChild(title);
+  header.appendChild(date);
+
+  return header;
+}
+
+/**
+ * Create a part header
+ * @param {number} part - Part number (1 or 2)
+ * @returns {HTMLElement} Part header element
+ */
+function createPartHeader(part) {
+  const header = document.createElement('div');
+  header.className = 'print-part-header';
+
+  if (part === 1) {
+    header.textContent = 'Part One: The Past Year';
+  } else if (part === 2) {
+    header.textContent = 'Part Two: The Year Ahead';
+  }
+
+  return header;
+}
+
+/**
+ * Render a section for print
+ * @param {Object} section - Section definition from questions.js
+ * @param {Object} answers - User's answers for this section
+ * @returns {HTMLElement} Section element
+ */
+function renderPrintSection(section, answers) {
+  const sectionEl = document.createElement('div');
+  sectionEl.className = 'section';
+  sectionEl.dataset.part = section.part;
+
+  // Section header
+  const header = document.createElement('header');
+  header.innerHTML = `
+    <h3 class="section-title">${escapeHtml(section.title)}</h3>
+    ${section.description ? `<p class="section-description">${escapeHtml(section.description)}</p>` : ''}
+  `;
+  sectionEl.appendChild(header);
+
+  // Render content based on section type
+  switch (section.type) {
+    case 'life-areas':
+      renderLifeAreasPrint(sectionEl, answers);
+      break;
+    case 'life-areas-goals':
+      renderLifeAreasGoalsPrint(sectionEl, answers);
+      break;
+    case 'triplets':
+      renderTripletsPrint(sectionEl, answers);
+      break;
+    default:
+      renderStandardPrint(sectionEl, section, answers);
+  }
+
+  return sectionEl;
+}
+
+/**
+ * Render standard fields for print
+ */
+function renderStandardPrint(container, section, answers) {
+  const fields = section.fields || [];
+
+  fields.forEach(field => {
+    const value = answers[field.id];
+    if (!value || (typeof value === 'string' && !value.trim())) return;
+
+    const fieldEl = document.createElement('div');
+    fieldEl.className = 'field';
+
+    if (field.prompt) {
+      const prompt = document.createElement('span');
+      prompt.className = 'field-prompt';
+      prompt.textContent = field.prompt;
+      fieldEl.appendChild(prompt);
+    }
+
+    const content = document.createElement('div');
+    content.className = 'markdown-preview';
+
+    if (field.markdown) {
+      content.innerHTML = renderMarkdown(value);
+    } else {
+      content.textContent = value;
+    }
+
+    fieldEl.appendChild(content);
+    container.appendChild(fieldEl);
+  });
+}
+
+/**
+ * Render life areas section for print
+ */
+function renderLifeAreasPrint(container, answers) {
+  lifeAreas.forEach(area => {
+    const rating = answers[`${area.id}-rating`];
+    const notes = answers[`${area.id}-notes`];
+
+    if (!rating && !notes) return;
+
+    const areaEl = document.createElement('div');
+    areaEl.className = 'life-area';
+
+    areaEl.innerHTML = `
+      <h4>${escapeHtml(area.label)}</h4>
+      ${rating ? `<div class="rating-control"><span class="rating-value">${rating}</span></div>` : ''}
+      ${notes ? `<div class="markdown-preview">${renderMarkdown(notes)}</div>` : ''}
+    `;
+
+    container.appendChild(areaEl);
+  });
+}
+
+/**
+ * Render life areas goals section for print
+ */
+function renderLifeAreasGoalsPrint(container, answers) {
+  lifeAreas.forEach(area => {
+    const goal = answers[`${area.id}-goal`];
+    const actions = answers[`${area.id}-actions`];
+
+    if (!goal && !actions) return;
+
+    const areaEl = document.createElement('div');
+    areaEl.className = 'life-area-goal';
+
+    let content = `<h4>${escapeHtml(area.label)}</h4>`;
+
+    if (goal) {
+      content += `
+        <div class="goal-field">
+          <label class="field-prompt">What do you want to achieve?</label>
+          <div class="markdown-preview">${renderMarkdown(goal)}</div>
+        </div>
+      `;
+    }
+
+    if (actions) {
+      content += `
+        <div class="actions-field">
+          <label class="field-prompt">What actions will you take?</label>
+          <div class="markdown-preview">${renderMarkdown(actions)}</div>
+        </div>
+      `;
+    }
+
+    areaEl.innerHTML = content;
+    container.appendChild(areaEl);
+  });
+}
+
+/**
+ * Render triplets section for print
+ */
+function renderTripletsPrint(container, answers) {
+  magicalTriplets.forEach(triplet => {
+    const items = [];
+    for (let i = 1; i <= 3; i++) {
+      const value = answers[`${triplet.id}-${i}`];
+      if (value && value.trim()) {
+        items.push(value);
+      }
+    }
+
+    if (items.length === 0) return;
+
+    const groupEl = document.createElement('div');
+    groupEl.className = 'triplet-group';
+
+    groupEl.innerHTML = `
+      <h4>${escapeHtml(triplet.prompt)}</h4>
+      <ol>
+        ${items.map(item => `<li>${escapeHtml(item)}</li>`).join('')}
+      </ol>
+    `;
+
+    container.appendChild(groupEl);
+  });
+}
+
+/**
+ * Check if answers object has any content
+ * @param {Object} answers - Answers object
+ * @returns {boolean} True if any non-empty values exist
+ */
+function hasContent(answers) {
+  if (!answers) return false;
+  return Object.values(answers).some(value =>
+    value && typeof value === 'string' ? value.trim().length > 0 : !!value
+  );
+}
+
+/**
+ * Format a date for display
+ * @param {Date} date - Date to format
+ * @returns {string} Formatted date string
+ */
+function formatDate(date) {
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  });
+}
+
+/**
+ * Escape HTML to prevent XSS
+ * @param {string} text - Text to escape
+ * @returns {string} Escaped text
+ */
+function escapeHtml(text) {
+  if (!text) return '';
+  const div = document.createElement('div');
+  div.textContent = text;
+  return div.innerHTML;
 }
 
 /**
  * Restore the document after printing
+ * @param {HTMLElement} printContainer - The container to remove
  */
-function restoreAfterPrint() {
-  // Remove print-only previews
-  const printPreviews = document.querySelectorAll('.print-only');
-  printPreviews.forEach(el => el.remove());
+function restoreAfterPrint(printContainer) {
+  // Remove print container
+  if (printContainer && printContainer.parentNode) {
+    printContainer.parentNode.removeChild(printContainer);
+  }
 
   // Remove print class
   document.body.classList.remove('printing');


### PR DESCRIPTION
Closes #8

## Summary

Implements PDF export functionality that renders all filled sections into a clean, print-ready format accessible via the browser's print dialog.

## Changes

### Print Styles (`css/print.css`)
- Hide all UI chrome during print (header, sidebar, footer, buttons)
- Clean typography using Georgia serif font at 11pt
- Section and field styling with proper page breaks
- Life areas display ratings as "Rating: X / 10"
- Triplet groups render as numbered lists
- Print container visible only during print, app hidden

### PDF Export Module (`js/pdf.js`)
- Creates dynamic print container with all sections containing content
- Adds print header with year title (e.g., "YearCompass 2025 → 2026") and export date
- Adds part headers ("Part One: The Past Year", "Part Two: The Year Ahead")
- Renders all section types: standard fields, life-areas, life-areas-goals, triplets
- Processes markdown content for print output
- Cleans up print container after dialog closes

### App Integration (`js/app.js`)
- Imports and initializes PDF export module on app load
- Export button now triggers the PDF export flow

## Test Plan

- [x] Click "Export to PDF" button in footer
- [x] Verify print container is created with filled sections only
- [x] Verify print header shows year and export date
- [x] Verify part headers separate Past Year and Year Ahead sections
- [x] Verify markdown content renders in print preview
- [x] Verify ratings display as "Rating: X / 10"

🤖 Generated with [Claude Code](https://claude.com/claude-code)