### PR TITLE
Mobile responsive layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -58,6 +58,13 @@ body {
   position: sticky;
   top: 0;
   z-index: 100;
+  gap: var(--spacing-md);
+}
+
+@media (max-width: 767px) {
+  .app-header {
+    padding: 0 var(--spacing-sm);
+  }
 }
 
 .app-title {
@@ -66,12 +73,30 @@ body {
   font-size: var(--font-size-xl);
   font-weight: 600;
   color: var(--color-text);
+  flex: 1;
+}
+
+@media (max-width: 767px) {
+  .app-title {
+    font-size: var(--font-size-lg);
+  }
 }
 
 .header-controls {
   display: flex;
   align-items: center;
   gap: var(--spacing-lg);
+}
+
+@media (max-width: 767px) {
+  .header-controls {
+    gap: var(--spacing-sm);
+  }
+
+  .year-selector {
+    max-width: 120px;
+    font-size: var(--font-size-xs);
+  }
 }
 
 .year-selector {
@@ -137,21 +162,23 @@ body {
   }
 }
 
+/* Sidebar Toggle - in header, visible only on mobile */
 .sidebar-toggle {
-  display: flex;
+  display: none;
   align-items: center;
   justify-content: center;
-  width: 40px;
-  height: 40px;
+  width: 44px;
+  height: 44px;
   padding: 0;
   background: none;
   border: none;
   cursor: pointer;
+  flex-shrink: 0;
 }
 
-@media (min-width: 768px) {
+@media (max-width: 767px) {
   .sidebar-toggle {
-    display: none;
+    display: flex;
   }
 }
 
@@ -197,6 +224,7 @@ body {
   align-items: center;
   width: 100%;
   padding: var(--spacing-sm) var(--spacing-md);
+  min-height: 44px; /* Touch-friendly minimum */
   text-align: left;
   text-decoration: none;
   color: var(--color-text);
@@ -225,6 +253,12 @@ body {
   overflow-y: auto;
   display: flex;
   justify-content: center;
+}
+
+@media (max-width: 767px) {
+  .main-content {
+    padding: var(--spacing-md);
+  }
 }
 
 .main-content > * {
@@ -265,6 +299,39 @@ body {
   text-align: right;
 }
 
+/* Mobile footer adjustments */
+@media (max-width: 767px) {
+  .app-footer {
+    height: auto;
+    min-height: var(--footer-height);
+    flex-wrap: wrap;
+    padding: var(--spacing-sm) var(--spacing-md);
+    gap: var(--spacing-sm);
+  }
+
+  .footer-left {
+    order: 2;
+    flex: 0 0 50%;
+  }
+
+  .footer-center {
+    order: 1;
+    flex: 0 0 100%;
+    justify-content: center;
+  }
+
+  .footer-right {
+    order: 3;
+    flex: 0 0 50%;
+  }
+
+  /* Hide export button on mobile - accessed via menu */
+  .footer-right .btn {
+    font-size: var(--font-size-xs);
+    padding: var(--spacing-xs) var(--spacing-sm);
+  }
+}
+
 .save-status {
   font-size: var(--font-size-sm);
   color: var(--color-text-muted);
@@ -291,6 +358,8 @@ body {
   border-radius: var(--border-radius);
   cursor: pointer;
   transition: all var(--transition-fast);
+  min-height: 44px; /* Touch-friendly minimum */
+  min-width: 44px;
 }
 
 .btn:disabled {
@@ -572,22 +641,30 @@ textarea {
     transition: transform var(--transition-base);
     z-index: 50;
     display: block;
+    box-shadow: var(--shadow-lg);
   }
 
   .sidebar.open {
     transform: translateX(0);
   }
 
-  .sidebar-toggle {
-    display: flex;
+  /* Overlay when sidebar is open */
+  .sidebar-overlay {
     position: fixed;
-    top: calc(var(--header-height) + var(--spacing-md));
-    left: var(--spacing-md);
+    top: var(--header-height);
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.5);
     z-index: 40;
-    background-color: var(--color-surface);
-    border: 1px solid var(--color-border);
-    border-radius: var(--border-radius);
-    box-shadow: var(--shadow-sm);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity var(--transition-base), visibility var(--transition-base);
+  }
+
+  .sidebar-overlay.visible {
+    opacity: 1;
+    visibility: visible;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -12,6 +12,10 @@
 <body>
   <div id="app">
     <header class="app-header">
+      <button class="sidebar-toggle" aria-expanded="false" aria-controls="sidebar-nav">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="hamburger"></span>
+      </button>
       <h1 class="app-title">YearCompass</h1>
       <div class="header-controls">
         <select id="year-selector" class="year-selector" aria-label="Select year">
@@ -28,10 +32,6 @@
 
     <div class="app-layout">
       <nav class="sidebar" aria-label="Section navigation">
-        <button class="sidebar-toggle" aria-expanded="true" aria-controls="sidebar-nav">
-          <span class="sr-only">Toggle navigation</span>
-          <span class="hamburger"></span>
-        </button>
         <ul id="sidebar-nav" class="nav-list">
           <!-- Navigation items populated by JS -->
         </ul>

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -139,12 +139,26 @@ function setupNavigationListeners() {
   const sidebar = document.querySelector('.sidebar');
 
   if (sidebarToggle && sidebar) {
+    // Create overlay element for mobile
+    let overlay = document.querySelector('.sidebar-overlay');
+    if (!overlay) {
+      overlay = document.createElement('div');
+      overlay.className = 'sidebar-overlay';
+      document.querySelector('.app-layout').appendChild(overlay);
+    }
+
+    // Toggle sidebar
     sidebarToggle.addEventListener('click', () => {
-      sidebar.classList.toggle('open');
-      sidebarToggle.setAttribute(
-        'aria-expanded',
-        sidebar.classList.contains('open')
-      );
+      const isOpen = sidebar.classList.toggle('open');
+      overlay.classList.toggle('visible', isOpen);
+      sidebarToggle.setAttribute('aria-expanded', isOpen);
+    });
+
+    // Close sidebar when clicking overlay
+    overlay.addEventListener('click', () => {
+      sidebar.classList.remove('open');
+      overlay.classList.remove('visible');
+      sidebarToggle.setAttribute('aria-expanded', 'false');
     });
   }
 }
@@ -215,6 +229,7 @@ export function navigateToSection(sectionId, showNudge = true) {
   const sidebar = document.querySelector('.sidebar');
   if (sidebar?.classList.contains('open')) {
     sidebar.classList.remove('open');
+    document.querySelector('.sidebar-overlay')?.classList.remove('visible');
     document.querySelector('.sidebar-toggle')?.setAttribute('aria-expanded', 'false');
   }
 


### PR DESCRIPTION
Closes #19

## Summary

Implements mobile-first responsive design with a slide-out navigation sidebar and touch-friendly interface.

## Changes

### HTML (`index.html`)
- Moved hamburger toggle button from inside sidebar to header
- Toggle now accessible when sidebar is hidden

### CSS (`css/styles.css`)
- Added responsive breakpoints (mobile < 768px)
- Header adjustments: smaller title, reduced padding on mobile
- Footer reordering: nav buttons centered on top, status/export on sides
- Touch-friendly tap targets: 44px minimum for all buttons and nav items
- Slide-out sidebar with `transform: translateX(-100%)` when closed
- Dark overlay (`.sidebar-overlay`) behind sidebar when open
- Reduced main content padding on mobile

### JavaScript (`js/navigation.js`)
- Creates overlay element dynamically on mobile
- Toggle button opens/closes sidebar with overlay
- Clicking overlay closes sidebar
- Navigation selection closes sidebar and overlay

## Test Plan

- [x] Mobile: Hamburger button visible in header
- [x] Mobile: Click toggle opens sidebar with overlay
- [x] Mobile: Click overlay closes sidebar
- [x] Mobile: Click nav item navigates AND closes sidebar
- [x] Mobile: Touch targets are 44px minimum
- [x] Desktop: Sidebar always visible
- [x] Desktop: Toggle button hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)